### PR TITLE
Add refresh ability to user tokens, and expose tokens for storage

### DIFF
--- a/examples/user_token.rs
+++ b/examples/user_token.rs
@@ -13,6 +13,10 @@ async fn main() {
             .ok()
             .or_else(|| args.next())
             .map(twitch_oauth2::RefreshToken::new),
+        std::env::var("TWITCH_CLIENT_SECRET")
+            .ok()
+            .or_else(|| args.next())
+            .map(twitch_oauth2::ClientSecret::new),
     )
     .await
     .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@
 //! # let reqwest_http_client = twitch_oauth2::dummy_http_client; // This is only here to fool doc tests
 //!     let token = AccessToken::new("sometokenherewhichisvalidornot".to_string());
 //!
-//!     match UserToken::from_existing(reqwest_http_client, token, None).await {
+//!     match UserToken::from_existing(reqwest_http_client, token, None, None).await {
 //!         Ok(t) => println!("user_token: {}", t.token().secret()),
 //!         Err(e) => panic!("got error: {}", e),
 //!     }

--- a/src/tokens/app_access_token.rs
+++ b/src/tokens/app_access_token.rs
@@ -61,8 +61,7 @@ impl AppAccessToken {
         client_secret: impl Into<ClientSecret>,
         login: Option<String>,
         scopes: Option<Vec<Scope>>,
-    ) -> AppAccessToken
-    {
+    ) -> AppAccessToken {
         AppAccessToken {
             access_token,
             refresh_token: None,

--- a/src/tokens/errors.rs
+++ b/src/tokens/errors.rs
@@ -48,6 +48,10 @@ pub enum RefreshTokenError<RE: std::error::Error + Send + Sync + 'static> {
     RequestError(#[source] RequestTokenError<RE, TwitchTokenErrorResponse>),
     /// could not parse url
     ParseError(#[from] oauth2::url::ParseError),
+    /// no client secret found
+    ///
+    /// A client secret is needed to request a refreshed token.
+    NoClientSecretFound,
     /// no refresh token found
     NoRefreshToken,
 }

--- a/src/tokens/user_token.rs
+++ b/src/tokens/user_token.rs
@@ -68,19 +68,16 @@ impl UserToken {
 
 #[async_trait::async_trait(?Send)]
 impl TwitchToken for UserToken {
-    fn client_id(&self) -> &ClientId {
-        &self.client_id
-    }
+    fn client_id(&self) -> &ClientId { &self.client_id }
 
-    fn token(&self) -> &AccessToken {
-        &self.access_token
-    }
+    fn token(&self) -> &AccessToken { &self.access_token }
 
-    fn login(&self) -> Option<&str> {
-        self.login.as_deref()
-    }
+    fn login(&self) -> Option<&str> { self.login.as_deref() }
 
-    async fn refresh_token<RE, C, F>(&mut self, http_client: C) -> Result<(), RefreshTokenError<RE>>
+    async fn refresh_token<RE, C, F>(
+        &mut self,
+        http_client: C,
+    ) -> Result<(), RefreshTokenError<RE>>
     where
         RE: std::error::Error + Send + Sync + 'static,
         C: FnOnce(HttpRequest) -> F,
@@ -97,15 +94,13 @@ impl TwitchToken for UserToken {
             self.access_token = access_token;
             self.expires = expires;
             self.refresh_token = refresh_token;
+            Ok(())
+        } else {
+            return Err(RefreshTokenError::NoClientSecretFound);
         }
-        Ok(())
     }
 
-    fn expires(&self) -> Option<std::time::Instant> {
-        None
-    }
+    fn expires(&self) -> Option<std::time::Instant> { None }
 
-    fn scopes(&self) -> Option<&[Scope]> {
-        Some(self.scopes.as_slice())
-    }
+    fn scopes(&self) -> Option<&[Scope]> { Some(self.scopes.as_slice()) }
 }

--- a/src/tokens/user_token.rs
+++ b/src/tokens/user_token.rs
@@ -2,6 +2,7 @@ use crate::tokens::{
     errors::{RefreshTokenError, ValidationError},
     Scope, TwitchToken,
 };
+use crate::ClientSecret;
 use oauth2::{AccessToken, ClientId, RefreshToken};
 use oauth2::{HttpRequest, HttpResponse};
 use std::future::Future;
@@ -9,10 +10,13 @@ use std::future::Future;
 /// An User Token from the [OAuth implicit code flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-implicit-code-flow) or [OAuth authorization code flow](https://dev.twitch.tv/docs/authentication/getting-tokens-oauth#oauth-authorization-code-flow)
 #[derive(Debug, Clone)]
 pub struct UserToken {
-    access_token: AccessToken,
+    /// The access token used to authenticate requests with
+    pub access_token: AccessToken,
     client_id: ClientId,
+    client_secret: Option<ClientSecret>,
     login: Option<String>,
-    refresh_token: Option<RefreshToken>,
+    /// The refresh token used to extend the life of this user token
+    pub refresh_token: Option<RefreshToken>,
     expires: Option<std::time::Instant>,
     scopes: Vec<Scope>,
 }
@@ -23,13 +27,14 @@ impl UserToken {
         access_token: impl Into<AccessToken>,
         refresh_token: impl Into<Option<RefreshToken>>,
         client_id: impl Into<ClientId>,
+        client_secret: impl Into<Option<ClientSecret>>,
         login: Option<String>,
         scopes: Option<Vec<Scope>>,
-    ) -> UserToken
-    {
+    ) -> UserToken {
         UserToken {
             access_token: access_token.into(),
             client_id: client_id.into(),
+            client_secret: client_secret.into(),
             login,
             refresh_token: refresh_token.into(),
             expires: None,
@@ -42,6 +47,7 @@ impl UserToken {
         http_client: C,
         access_token: AccessToken,
         refresh_token: impl Into<Option<RefreshToken>>,
+        client_secret: impl Into<Option<ClientSecret>>,
     ) -> Result<UserToken, ValidationError<RE>>
     where
         RE: std::error::Error + Send + Sync + 'static,
@@ -53,6 +59,7 @@ impl UserToken {
             access_token,
             refresh_token.into(),
             validated.client_id,
+            client_secret,
             validated.login,
             validated.scopes,
         ))
@@ -61,21 +68,44 @@ impl UserToken {
 
 #[async_trait::async_trait(?Send)]
 impl TwitchToken for UserToken {
-    fn client_id(&self) -> &ClientId { &self.client_id }
+    fn client_id(&self) -> &ClientId {
+        &self.client_id
+    }
 
-    fn token(&self) -> &AccessToken { &self.access_token }
+    fn token(&self) -> &AccessToken {
+        &self.access_token
+    }
 
-    fn login(&self) -> Option<&str> { self.login.as_deref() }
+    fn login(&self) -> Option<&str> {
+        self.login.as_deref()
+    }
 
-    async fn refresh_token<RE, C, F>(&mut self, _: C) -> Result<(), RefreshTokenError<RE>>
+    async fn refresh_token<RE, C, F>(&mut self, http_client: C) -> Result<(), RefreshTokenError<RE>>
     where
         RE: std::error::Error + Send + Sync + 'static,
         C: FnOnce(HttpRequest) -> F,
-        F: Future<Output = Result<HttpResponse, RE>>, {
-        Err(RefreshTokenError::NoRefreshToken)
+        F: Future<Output = Result<HttpResponse, RE>>,
+    {
+        if let Some(client_secret) = self.client_secret.clone() {
+            let (access_token, expires, refresh_token) = if let Some(token) =
+                self.refresh_token.take()
+            {
+                crate::refresh_token(http_client, token, &self.client_id, &client_secret).await?
+            } else {
+                return Err(RefreshTokenError::NoRefreshToken);
+            };
+            self.access_token = access_token;
+            self.expires = expires;
+            self.refresh_token = refresh_token;
+        }
+        Ok(())
     }
 
-    fn expires(&self) -> Option<std::time::Instant> { None }
+    fn expires(&self) -> Option<std::time::Instant> {
+        None
+    }
 
-    fn scopes(&self) -> Option<&[Scope]> { Some(self.scopes.as_slice()) }
+    fn scopes(&self) -> Option<&[Scope]> {
+        Some(self.scopes.as_slice())
+    }
 }


### PR DESCRIPTION
This changes the API by adding an extra (optional) client secret field.

I also make some fields pub so that an application can retrieve them post-refresh and store them for the next run.