### PR TITLE
don't enable surf features by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest]
-        rust: [1.49, nightly]
+        rust: [1.51, nightly]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Added a way to suggest or infer that an user token is never expiring, making `is_elapsed` return false and `expires_in` a bogus (max) duration.
 ### Changed
 
-* MSRV: 1.49 
+* MSRV: 1.51
 * Made scope take `Cow<&'static str>`
 * Made fields `access_token`, `refresh_token`, `user_id` and `login` `pub` on `UserToken` and `AppAccessToken` (where applicable)
 * Fixed wrong scope `user:read:stream_key` -> `channel:read:stream_key`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,15 @@ keywords = ["oauth", "twitch", "async", "asynchronous"]
 documentation = "https://docs.rs/twitch_oauth2/0.4.1"
 readme = "README.md"
 build = "build.rs"
+resolver = "2"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = []
 reqwest_client = ["oauth2/reqwest"]
+surf_client_curl = ["surf_client", "surf/curl-client"]
 surf_client = ["surf", "http-types", "http-types/hyperium_http"]
-all = ["surf_client", "reqwest_client"]
+all = ["surf_client_curl", "reqwest_client"]
 
 [dependencies]
 oauth2 = { version = "4.0.0", features = [], default-features = false }
@@ -25,7 +28,7 @@ serde = "1.0.125"
 serde_json = "1.0.64"
 async-trait = "0.1.50"
 http = "0.2.4"
-surf = { version = "2.1.0", optional = true }
+surf = { version = "2.1.0", optional = true, default-features = false }
 http-types = { version = "2.9.0", optional = true }
 
 [dev-dependencies]
@@ -33,6 +36,7 @@ tokio = { version = "1.5.0", features = ["rt-multi-thread", "macros", "test-util
 dotenv = "0.15.0"
 anyhow = "1.0.40"
 reqwest = { version = "0.11.3" }
+surf = { version = "2.1.0" }
 
 [build-dependencies]
 version_check = "0.9.3"
@@ -43,4 +47,4 @@ path = "examples/user_token.rs"
 required-features = ["surf_client"]
 
 [package.metadata.docs.rs]
-features = ["reqwest_client", "surf_client"]
+features = ["all"]


### PR DESCRIPTION
this will make `surf_client` not pull in curl, requiring the user to specify surf in their `Cargo.toml` or using feature `surf_client_curl`.
