### PR TITLE
mock refactor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,4 +3,5 @@
     "rust-analyzer.checkOnSave.features": ["all"],
     "rust-analyzer.checkOnSave.enable": true,
     "rust-analyzer.cargo.features": ["all"],
+    "rust-analyzer.experimental.procAttrMacros": true
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,10 +57,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.41"
+name = "aliri_braid"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15af2628f6890fe2609a3b91bef4c83450512802e59489f9c1cb1fa5df064a61"
+checksum = "4961918d91b2182cf3adc6e3cd8d6f44452e0f42db367691447af31afdd1ad7d"
+dependencies = [
+ "aliri_braid_impl",
+]
+
+[[package]]
+name = "aliri_braid_impl"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e21d6298c933984056b381a70c7248a97370b76dfdbc95dc3da0fcbcd994342"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
 
 [[package]]
 name = "async-channel"
@@ -105,12 +125,11 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.4.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bbfd5cf2794b1e908ea8457e6c45f8f8f1f6ec5f74617bf4662623f47503c3b"
+checksum = "a811e6a479f2439f0c04038796b5cfb3d2ad56c230e0f2d3f7b04d68cfee607b"
 dependencies = [
  "concurrent-queue",
- "fastrand",
  "futures-lite",
  "libc",
  "log",
@@ -176,9 +195,9 @@ checksum = "e91831deabf0d6d7ec49552e489aed63b7456a7a3c46cff62adad428110b0af0"
 
 [[package]]
 name = "async-trait"
-version = "0.1.50"
+version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+checksum = "44318e776df68115a881de9a8fd1b9e53368d7a4a5ce4cc48517da3393233a5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -264,28 +283,15 @@ checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
 name = "cc"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72c244c1ff497a746a7e1fb3d14bd08420ecda70c8f25c7112f2781652d787"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "serde",
- "winapi",
-]
 
 [[package]]
 name = "cipher"
@@ -346,9 +352,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
 dependencies = [
  "libc",
 ]
@@ -371,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
 dependencies = [
  "generic-array",
  "subtle",
@@ -415,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.44+curl-7.77.0"
+version = "0.4.45+curl-7.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6d85e9322b193f117c966e79c2d6929ec08c02f339f950044aba12e20bbaf1"
+checksum = "de9e5a72b1c744eb5dd20b2be4d7eb84625070bb5c4ab9b347b70464ab1e62eb"
 dependencies = [
  "cc",
  "libc",
@@ -462,9 +468,9 @@ checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "displaydoc"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3274a6bc8a6a4521291b53b9dcb8345e963fe931c3fc462a7d3ead71d7ccd30d"
+checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -494,9 +500,9 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "fastrand"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b705829d1e87f762c2df6da140b26af5839e1033aa84aa5f56bb688e4e1bdb"
+checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
 dependencies = [
  "instant",
 ]
@@ -545,24 +551,24 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
 
 [[package]]
 name = "futures-io"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc499defb3b348f8d8f3f66415835a9131856ff7714bf10dadfc4ec4bdb29a1"
+checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
 
 [[package]]
 name = "futures-lite"
@@ -581,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c40298486cdf52cc00cd6d6987892ba502c7656a16a4192a9992b1ccedd121"
+checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -594,21 +600,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
 
 [[package]]
 name = "futures-task"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
 
 [[package]]
 name = "futures-util"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
 dependencies = [
  "autocfg",
  "futures-core",
@@ -651,10 +657,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -701,15 +705,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -808,9 +812,9 @@ checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
 name = "hyper"
-version = "0.14.9"
+version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d6baa1b441335f3ce5098ac421fb6547c46dda735ca1bc6d0153c838f9dd83"
+checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
@@ -856,9 +860,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -872,9 +876,9 @@ checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if",
 ]
@@ -940,9 +944,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.97"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -1063,25 +1067,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,26 +1074,6 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
-]
-
-[[package]]
-name = "oauth2"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e47cfc4c0a1a519d9a025ebfbac3a2439d1b5cdf397d72dcb79b11d9920dab"
-dependencies = [
- "base64",
- "chrono",
- "getrandom 0.2.3",
- "http",
- "rand 0.8.4",
- "reqwest",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2",
- "thiserror",
- "url",
 ]
 
 [[package]]
@@ -1125,9 +1090,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.34"
+version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1145,9 +1110,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.63"
+version = "0.9.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
+checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
 dependencies = [
  "autocfg",
  "cc",
@@ -1170,18 +1135,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
+checksum = "576bc800220cc65dac09e99e97b08b358cfab6e17078de8dc5fee223bd2d0c08"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
+checksum = "6e8fe8163d14ce7f0cdac2e040116f22eac817edabff0be91e8aff7e9accf389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1190,9 +1155,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -1250,9 +1215,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -1367,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+checksum = "246e9f61b9bb77df069a947682be06e31ac43ea37862e244a69f177694ea6d22"
 dependencies = [
  "base64",
  "bytes 1.0.1",
@@ -1480,18 +1445,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f03b9878abf6d14e6779d3f24f07b2cfa90352cfec4acc5aab8f1ac7f146fae8"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "a024926d3432516606328597e0f224a51355a493b49fdd67e9209187cbe55ecc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1500,21 +1465,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
 dependencies = [
  "itoa",
  "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_path_to_error"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f6109f0506e20f7e0f910e51a0079acf41da8e0694e6442527c4ddf5a2b158"
-dependencies = [
  "serde",
 ]
 
@@ -1580,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+checksum = "765f090f0e423d2b55843402a07915add955e7d60657db13707a159727326cad"
 dependencies = [
  "libc",
  "winapi",
@@ -1657,9 +1613,9 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "subtle"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "surf"
@@ -1685,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f71489ff30030d2ae598524f61326b902466f72a0fb1a8564c001cc63425bcc7"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1710,18 +1666,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa6f76457f59514c7eeb4e59d891395fab0b2fd1d40723ae737d64153392e9c6"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a36768c0fbf1bb15eca10defa29526bda730a2376c2ab4393ccfa16fb1a318d"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1768,9 +1724,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
+checksum = "848a1e1181b9f6753b5e96a092749e29b11d19ede67dfbbd6c7dc7e0f49b5338"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1783,9 +1739,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79ba603c337335df6ba6dd6afc38c38a7d5e1b0c871678439ea973cd62a118e"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -1800,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1892,14 +1848,16 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 name = "twitch_oauth2"
 version = "0.5.2"
 dependencies = [
+ "aliri_braid",
  "anyhow",
  "async-trait",
+ "base64",
  "displaydoc",
  "dotenv",
  "http",
  "http-types",
- "oauth2",
  "once_cell",
+ "rand 0.8.4",
  "reqwest",
  "rpassword",
  "serde",
@@ -1907,6 +1865,7 @@ dependencies = [
  "surf",
  "thiserror",
  "tokio",
+ "url",
  "version_check",
 ]
 
@@ -1951,9 +1910,9 @@ checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "universal-hash"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
  "generic-array",
  "subtle",
@@ -1984,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70455df2fdf4e9bf580a92e443f1eb0303c390d682e2ea817312c9e81f8c3399"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,12 +205,6 @@ checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
@@ -290,7 +284,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time 0.1.43",
  "winapi",
 ]
 
@@ -325,13 +318,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
 dependencies = [
  "aes-gcm",
- "base64 0.13.0",
+ "base64",
  "hkdf",
  "hmac",
  "percent-encoding",
  "rand 0.8.4",
  "sha2",
- "time 0.2.27",
+ "time",
  "version_check",
 ]
 
@@ -658,8 +651,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -785,7 +780,7 @@ dependencies = [
  "anyhow",
  "async-channel",
  "async-std",
- "base64 0.13.0",
+ "base64",
  "cookie",
  "futures-lite",
  "http",
@@ -1098,14 +1093,15 @@ dependencies = [
 
 [[package]]
 name = "oauth2"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ad4d0136960353683efa6160b9c867088b4b8f567b762cd37420a10ce32703"
+checksum = "80e47cfc4c0a1a519d9a025ebfbac3a2439d1b5cdf397d72dcb79b11d9920dab"
 dependencies = [
- "base64 0.12.3",
+ "base64",
  "chrono",
+ "getrandom 0.2.3",
  "http",
- "rand 0.7.3",
+ "rand 0.8.4",
  "reqwest",
  "serde",
  "serde_json",
@@ -1375,7 +1371,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
 dependencies = [
- "base64 0.13.0",
+ "base64",
  "bytes 1.0.1",
  "encoding_rs",
  "futures-core",
@@ -1734,16 +1730,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
@@ -1913,6 +1899,7 @@ dependencies = [
  "http",
  "http-types",
  "oauth2",
+ "once_cell",
  "reqwest",
  "rpassword",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,13 @@ required-features = ["reqwest_client"]
 
 
 [[example]]
-name = "mock"
-path = "examples/mock.rs"
+name = "mock_app"
+path = "examples/mock_app.rs"
+required-features = ["reqwest_client", "mock_api"]
+
+[[example]]
+name = "mock_user"
+path = "examples/mock_user.rs"
 required-features = ["reqwest_client", "mock_api"]
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 reqwest_client = ["oauth2/reqwest"]
 surf_client_curl = ["surf_client", "surf/curl-client"]
 surf_client = ["surf", "http-types", "http-types/hyperium_http"]
+mock_api = []
 all = ["surf_client_curl", "reqwest_client"]
 
 [dependencies]
@@ -30,6 +31,7 @@ async-trait = "0.1.50"
 http = "0.2.4"
 surf = { version = "2.2.0", optional = true, default-features = false }
 http-types = { version = "2.11.1", optional = true }
+once_cell = "1.8.0"
 
 [dev-dependencies]
 tokio = { version = "1.7.0", features = ["rt-multi-thread", "macros", "test-util"] }
@@ -51,6 +53,12 @@ required-features = ["surf_client"]
 name = "auth_flow"
 path = "examples/auth_flow.rs"
 required-features = ["reqwest_client"]
+
+
+[[example]]
+name = "mock"
+path = "examples/mock.rs"
+required-features = ["reqwest_client", "mock_api"]
 
 [package.metadata.docs.rs]
 features = ["all"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,11 @@ path = "examples/user_token.rs"
 required-features = ["surf_client"]
 
 [[example]]
+name = "app_access_token"
+path = "examples/app_access_token.rs"
+required-features = ["surf_client"]
+
+[[example]]
 name = "auth_flow"
 path = "examples/auth_flow.rs"
 required-features = ["reqwest_client"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,29 +15,33 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 default = []
-reqwest_client = ["oauth2/reqwest"]
+reqwest_client = ["reqwest"]
 surf_client_curl = ["surf_client", "surf/curl-client"]
 surf_client = ["surf", "http-types", "http-types/hyperium_http"]
 mock_api = []
 all = ["surf_client_curl", "reqwest_client"]
 
 [dependencies]
-oauth2 = { version = "4.0.0", features = [], default-features = false }
 thiserror = "1.0.25"
 displaydoc = "0.2.1"
-serde = "1.0.126"
+serde = {version = "1.0.126", features = ["derive"]}
 serde_json = "1.0.64"
 async-trait = "0.1.50"
 http = "0.2.4"
 surf = { version = "2.2.0", optional = true, default-features = false }
+reqwest = { version = "0.11.4", optional = true, default-features = false }
 http-types = { version = "2.11.1", optional = true }
 once_cell = "1.8.0"
+aliri_braid = "0.1.9"
+url = "2.2.2"
+base64 = "0.13"
+rand = "0.8.4"
 
 [dev-dependencies]
 tokio = { version = "1.7.0", features = ["rt-multi-thread", "macros", "test-util"] }
 dotenv = "0.15.0"
 anyhow = "1.0.41"
-reqwest = "0.11.3"
+reqwest = "0.11.4"
 surf = "2.2.0"
 rpassword = "5.0.1"
 

--- a/examples/app_access_token.rs
+++ b/examples/app_access_token.rs
@@ -1,0 +1,37 @@
+use twitch_oauth2::{client, TwitchToken};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let _ = dotenv::dotenv(); // Eat error
+    let mut args = std::env::args().skip(1);
+
+    let client_id = std::env::var("TWITCH_CLIENT_ID")
+        .ok()
+        .or_else(|| args.next())
+        .map(twitch_oauth2::ClientId::new)
+        .expect("Please set env: TWITCH_CLIENT_ID or pass client id as an argument");
+
+    let client_secret = std::env::var("TWITCH_CLIENT_SECRET")
+        .ok()
+        .or_else(|| args.next())
+        .map(twitch_oauth2::ClientSecret::new)
+        .expect("Please set env: TWITCH_CLIENT_SECRET or pass client secret as an argument");
+
+    let scopes = std::env::var("CLIENT_SCOPES")
+        .ok()
+        .map(|s| s.split(' ').map(|s| s.to_string()).collect::<Vec<_>>())
+        .or_else(|| Some(args.collect::<Vec<_>>()))
+        .map(|v| v.into_iter().map(twitch_oauth2::Scope::from).collect())
+        .expect("Please set env: CLIENT_SCOPES or pass client secret as an argument");
+
+    let token = twitch_oauth2::AppAccessToken::get_app_access_token(
+        twitch_oauth2::client::surf_http_client,
+        client_id,
+        client_secret,
+        scopes,
+    )
+    .await?;
+    println!("{:?}", token);
+    dbg!(token.is_elapsed());
+    Ok(())
+}

--- a/examples/app_access_token.rs
+++ b/examples/app_access_token.rs
@@ -25,7 +25,7 @@ async fn main() -> anyhow::Result<()> {
         .expect("Please set env: CLIENT_SCOPES or pass client secret as an argument");
 
     let token = twitch_oauth2::AppAccessToken::get_app_access_token(
-        twitch_oauth2::client::surf_http_client,
+        &surf::Client::new(),
         client_id,
         client_secret,
         scopes,

--- a/examples/app_access_token.rs
+++ b/examples/app_access_token.rs
@@ -1,4 +1,4 @@
-use twitch_oauth2::{client, TwitchToken};
+use twitch_oauth2::TwitchToken;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/mock.rs
+++ b/examples/mock.rs
@@ -1,0 +1,38 @@
+use twitch_oauth2::TwitchToken;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let _ = dotenv::dotenv(); // Eat error
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "trace");
+    }
+    tracing_subscriber::fmt::init();
+    let mut args = std::env::args().skip(1);
+    std::env::var("TWITCH_OAUTH2_URL")
+        .ok()
+        .or_else(|| args.next())
+        .map(|t| std::env::set_var("TWITCH_OAUTH2_URL", &t))
+        .expect("Please set env: TWITCH_OAUTH2_URL or pass url as first argument");
+
+    let client_id = std::env::var("MOCK_CLIENT_ID")
+        .ok()
+        .or_else(|| args.next())
+        .map(twitch_oauth2::ClientId::new)
+        .expect("Please set env: MOCK_CLIENT_ID or pass client id as an argument");
+
+    let client_secret = std::env::var("MOCK_CLIENT_SECRET")
+        .ok()
+        .or_else(|| args.next())
+        .map(twitch_oauth2::ClientSecret::new)
+        .expect("Please set env: MOCK_CLIENT_SECRET or pass client secret as an argument");
+
+    let token = twitch_oauth2::AppAccessToken::get_app_access_token(
+        twitch_oauth2::client::reqwest2_http_client,
+        client_id,
+        client_secret,
+        vec![],
+    )
+    .await?;
+    println!("token");
+    Ok(())
+}

--- a/examples/mock.rs
+++ b/examples/mock.rs
@@ -3,10 +3,7 @@ use twitch_oauth2::TwitchToken;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let _ = dotenv::dotenv(); // Eat error
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "trace");
-    }
-    tracing_subscriber::fmt::init();
+
     let mut args = std::env::args().skip(1);
     std::env::var("TWITCH_OAUTH2_URL")
         .ok()
@@ -27,7 +24,9 @@ async fn main() -> anyhow::Result<()> {
         .expect("Please set env: MOCK_CLIENT_SECRET or pass client secret as an argument");
 
     let token = twitch_oauth2::AppAccessToken::get_app_access_token(
-        twitch_oauth2::client::reqwest2_http_client,
+        &reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?,
         client_id,
         client_secret,
         vec![],

--- a/examples/mock.rs
+++ b/examples/mock.rs
@@ -32,6 +32,6 @@ async fn main() -> anyhow::Result<()> {
         vec![],
     )
     .await?;
-    println!("token");
+    println!("token retrieved: {} - {:?}", token.access_token.secret(), token);
     Ok(())
 }

--- a/examples/mock_app.rs
+++ b/examples/mock_app.rs
@@ -1,5 +1,3 @@
-use twitch_oauth2::TwitchToken;
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let _ = dotenv::dotenv(); // Eat error

--- a/examples/mock_app.rs
+++ b/examples/mock_app.rs
@@ -32,6 +32,10 @@ async fn main() -> anyhow::Result<()> {
         vec![],
     )
     .await?;
-    println!("token retrieved: {} - {:?}", token.access_token.secret(), token);
+    println!(
+        "token retrieved: {} - {:?}",
+        token.access_token.secret(),
+        token
+    );
     Ok(())
 }

--- a/examples/mock_user.rs
+++ b/examples/mock_user.rs
@@ -1,0 +1,49 @@
+use twitch_oauth2::TwitchToken;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let _ = dotenv::dotenv(); // Eat error
+
+    let mut args = std::env::args().skip(1);
+    std::env::var("TWITCH_OAUTH2_URL")
+        .ok()
+        .or_else(|| args.next())
+        .map(|t| std::env::set_var("TWITCH_OAUTH2_URL", &t))
+        .expect("Please set env: TWITCH_OAUTH2_URL or pass url as first argument");
+
+    let client_id = std::env::var("MOCK_CLIENT_ID")
+        .ok()
+        .or_else(|| args.next())
+        .map(twitch_oauth2::ClientId::new)
+        .expect("Please set env: MOCK_CLIENT_ID or pass client id as an argument");
+
+    let client_secret = std::env::var("MOCK_CLIENT_SECRET")
+        .ok()
+        .or_else(|| args.next())
+        .map(twitch_oauth2::ClientSecret::new)
+        .expect("Please set env: MOCK_CLIENT_SECRET or pass client secret as an argument");
+
+    let user_id = std::env::var("MOCK_USER_ID")
+        .ok()
+        .or_else(|| args.next())
+        .map(twitch_oauth2::ClientSecret::new)
+        .expect("Please set env: MOCK_USER_ID or pass user_id as an argument");
+
+    let token = twitch_oauth2::UserToken::mock_token(
+        &reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?,
+        url::Url::parse("http://localhost:8080/mock/users").unwrap(),
+        client_id,
+        client_secret,
+        user_id,
+        vec![],
+    )
+    .await?;
+    println!(
+        "token retrieved: {} - {:?}",
+        token.access_token.secret(),
+        token
+    );
+    Ok(())
+}

--- a/examples/mock_user.rs
+++ b/examples/mock_user.rs
@@ -1,5 +1,3 @@
-use twitch_oauth2::TwitchToken;
-
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let _ = dotenv::dotenv(); // Eat error

--- a/examples/mock_user.rs
+++ b/examples/mock_user.rs
@@ -33,7 +33,7 @@ async fn main() -> anyhow::Result<()> {
         &reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
             .build()?,
-        url::Url::parse("http://localhost:8080/mock/users").unwrap(),
+        None,
         client_id,
         client_secret,
         user_id,

--- a/examples/user_token.rs
+++ b/examples/user_token.rs
@@ -5,7 +5,7 @@ async fn main() -> anyhow::Result<()> {
     let _ = dotenv::dotenv(); // Eat error
     let mut args = std::env::args().skip(1);
     let token = twitch_oauth2::UserToken::from_existing(
-        twitch_oauth2::client::surf_http_client,
+        &surf::Client::new(),
         std::env::var("TWITCH_TOKEN")
             .ok()
             .or_else(|| args.next())

--- a/src/client.rs
+++ b/src/client.rs
@@ -24,6 +24,23 @@ pub trait Client<'a>: Sync + Send + 'a {
     ) -> BoxedFuture<'a, Result<crate::HttpResponse, <Self as Client>::Error>>;
 }
 
+#[doc(hidden)]
+#[derive(Debug, thiserror::Error, Clone)]
+#[error("this client does not do anything, only used for documentation test that only checks code integrity")]
+pub struct DummyClient;
+
+#[cfg(feature = "reqwest")]
+#[cfg_attr(nightly, doc(cfg(feature = "reqwest_client")))] // FIXME: This doc_cfg does nothing
+impl<'a> Client<'a> for DummyClient {
+    type Error = DummyClient;
+
+    fn req(
+        &'a self,
+        _: crate::HttpRequest,
+    ) -> BoxedFuture<'a, Result<crate::HttpResponse, Self::Error>> {
+        Box::pin(async move { Err(self.clone()) })
+    }
+}
 #[cfg(feature = "reqwest")]
 use reqwest::Client as ReqwestClient;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,68 +1,153 @@
 //! Provides different http clients
 //!
-//! If you want to provide your own client, see [oauth2] documentation.
-#[doc(inline)]
-#[cfg(feature = "reqwest_client")]
-#[cfg_attr(nightly, doc(cfg(feature = "reqwest_client")))]
-pub use oauth2::reqwest::async_http_client as reqwest_http_client;
 
-#[doc(inline)]
-#[cfg(feature = "surf_client")]
-pub use surf_client::http_client as surf_http_client;
+// This module is heavily inspired (read: copied) by twitch_api2::client.
 
-#[doc(inline)]
-#[cfg(feature = "surf_client")]
-pub use surf_client::Error as SurfError;
+use std::error::Error;
+use std::future::Future;
 
-#[cfg(feature = "surf_client")]
-mod surf_client {
-    use oauth2::{HttpRequest, HttpResponse};
+/// The User-Agent `product` of this crate.
+pub static TWITCH_OAUTH2_USER_AGENT: &str =
+    concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION"),);
 
-    /// Possible errors for [surf_http_client][http_client]
-    #[derive(Debug, displaydoc::Display, thiserror::Error)]
-    pub enum Error {
-        /// surf failed to do the request: {0}
-        Surf(surf::Error),
-        /// could not construct header value
-        InvalidHeaderValue(#[from] oauth2::http::header::InvalidHeaderValue),
-        /// could not construct header name
-        InvalidHeaderName(#[from] oauth2::http::header::InvalidHeaderName),
+/// A boxed future, mimics `futures::future::BoxFuture`
+type BoxedFuture<'a, T> = std::pin::Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// A client that can do OAUTH2 requests
+pub trait Client<'a>: Sync + Send + 'a {
+    /// Error returned by the client
+    type Error: Error + Send + Sync + 'static;
+    /// Send a request
+    fn req(
+        &'a self,
+        request: crate::HttpRequest,
+    ) -> BoxedFuture<'a, Result<crate::HttpResponse, <Self as Client>::Error>>;
+}
+
+#[cfg(feature = "reqwest")]
+use reqwest::Client as ReqwestClient;
+
+#[cfg(feature = "reqwest")]
+#[cfg_attr(nightly, doc(cfg(feature = "reqwest_client")))] // FIXME: This doc_cfg does nothing
+impl<'a> Client<'a> for ReqwestClient {
+    type Error = reqwest::Error;
+
+    fn req(
+        &'a self,
+        request: crate::HttpRequest,
+    ) -> BoxedFuture<'a, Result<crate::HttpResponse, Self::Error>> {
+        // Reqwest plays really nice here and has a try_from on `http::Request` -> `reqwest::Request`
+        use std::convert::TryFrom;
+        let req = match reqwest::Request::try_from(request) {
+            Ok(req) => req,
+            Err(e) => return Box::pin(async { Err(e) }),
+        };
+        // We need to "call" the execute outside the async closure to not capture self.
+        let fut = self.execute(req);
+        Box::pin(async move {
+            // Await the request and translate to `http::Response`
+            let mut response = fut.await?;
+            let mut result = http::Response::builder();
+            let headers = result
+                .headers_mut()
+                // This should not fail, we just created the response.
+                .expect("expected to get headers mut when building response");
+            std::mem::swap(headers, response.headers_mut());
+            let result = result.version(response.version());
+            Ok(result
+                .body(response.bytes().await?.as_ref().to_vec())
+                .expect("mismatch reqwest -> http conversion should not fail"))
+        })
     }
+}
 
-    ///  Asynchronous HTTP client using [Surf][surf::Client]
-    #[cfg_attr(nightly, doc(cfg(feature = "surf_client")))]
-    pub async fn http_client(request: HttpRequest) -> Result<HttpResponse, Error> {
-        #[cfg(not(doc))]
-        {
-            let client = surf::Client::new(); // If this fails to compile, please use feature `surf_client_curl` or specify surf with a client in Cargo.toml
-            let method: http_types::Method = request.method.into();
-            let mut req = surf::Request::new(method, request.url);
+#[cfg(feature = "surf")]
+use surf::Client as SurfClient;
 
-            for (name, value) in &request.headers {
-                let value = surf::http::headers::HeaderValue::from_bytes(value.as_bytes().to_vec())
-                    .map_err(Error::Surf)?;
-                req.append_header(name.as_str(), value);
-            }
+/// Possible errors from [`Client::req()`] when using the [surf](https://crates.io/crates/surf) client
+///
+/// Also returned by [`ClientDefault::default_client_with_name`]
+#[cfg(feature = "surf")]
+#[derive(Debug, displaydoc::Display, thiserror::Error)]
+pub enum SurfError {
+    /// surf failed to do the request: {0}
+    Surf(surf::Error),
+    /// could not construct header value
+    InvalidHeaderValue(#[from] http::header::InvalidHeaderValue),
+    /// could not construct header name
+    InvalidHeaderName(#[from] http::header::InvalidHeaderName),
+    /// uri could not be translated into an url.
+    UrlError(#[from] url::ParseError),
+}
 
-            req.body_bytes(&request.body);
+#[cfg(feature = "surf")]
+#[cfg_attr(nightly, doc(cfg(feature = "surf_client")))] // FIXME: This doc_cfg does nothing
+impl<'a> Client<'a> for SurfClient {
+    type Error = SurfError;
 
-            let mut response = client.send(req).await.map_err(Error::Surf)?;
-            let headers = response
+    fn req(
+        &'a self,
+        request: crate::HttpRequest,
+    ) -> BoxedFuture<'a, Result<crate::HttpResponse, Self::Error>> {
+        // First we translate the `http::Request` method and uri into types that surf understands.
+
+        let method: surf::http::Method = request.method().clone().into();
+
+        let url = match url::Url::parse(&request.uri().to_string()) {
+            Ok(url) => url,
+            Err(err) => return Box::pin(async move { Err(err.into()) }),
+        };
+        // Construct the request
+        let mut req = surf::Request::new(method, url);
+
+        // move the headers into the surf request
+        for (name, value) in request.headers().iter() {
+            let value =
+                match surf::http::headers::HeaderValue::from_bytes(value.as_bytes().to_vec())
+                    .map_err(SurfError::Surf)
+                {
+                    Ok(val) => val,
+                    Err(err) => return Box::pin(async { Err(err) }),
+                };
+            req.append_header(name.as_str(), value);
+        }
+
+        // assembly the request, now we can send that to our `surf::Client`
+        req.body_bytes(&request.body());
+
+        let client = self.clone();
+        Box::pin(async move {
+            // Send the request and translate the response into a `http::Response`
+            let mut response = client.send(req).await.map_err(SurfError::Surf)?;
+            let mut result = http::Response::builder();
+
+            let mut response_headers: http::header::HeaderMap = response
                 .iter()
                 .map(|(k, v)| {
                     Ok((
-                        oauth2::http::header::HeaderName::from_bytes(k.as_str().as_bytes())?,
-                        oauth2::http::HeaderValue::from_str(v.as_str())?,
+                        http::header::HeaderName::from_bytes(k.as_str().as_bytes())?,
+                        http::HeaderValue::from_str(v.as_str())?,
                     ))
                 })
-                .collect::<Result<_, Error>>()?;
-            Ok(HttpResponse {
-                body: response.body_bytes().await.map_err(Error::Surf)?,
-                status_code: response.status().into(),
-                headers,
-            })
-        }
-        #[cfg(doc)]
-        unimplemented!("A client for surf is not provided in documentation generation due to needing a specified surf client, like `curl-client`")
+                .collect::<Result<_, SurfError>>()?;
+
+            let _ = std::mem::replace(&mut result.headers_mut(), Some(&mut response_headers));
+            let result = if let Some(v) = response.version() {
+                result.version(match v {
+                    surf::http::Version::Http0_9 => http::Version::HTTP_09,
+                    surf::http::Version::Http1_0 => http::Version::HTTP_10,
+                    surf::http::Version::Http1_1 => http::Version::HTTP_11,
+                    surf::http::Version::Http2_0 => http::Version::HTTP_2,
+                    surf::http::Version::Http3_0 => http::Version::HTTP_3,
+                    // TODO: Log this somewhere...
+                    _ => http::Version::HTTP_3,
+                })
+            } else {
+                result
+            };
+            Ok(result
+                .body(response.body_bytes().await.map_err(SurfError::Surf)?)
+                .expect("mismatch surf -> http conversion should not fail"))
+        })
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -82,8 +82,6 @@ impl<'a> Client<'a> for ReqwestClient {
 use surf::Client as SurfClient;
 
 /// Possible errors from [`Client::req()`] when using the [surf](https://crates.io/crates/surf) client
-///
-/// Also returned by [`ClientDefault::default_client_with_name`]
 #[cfg(feature = "surf")]
 #[derive(Debug, displaydoc::Display, thiserror::Error)]
 pub enum SurfError {

--- a/src/id.rs
+++ b/src/id.rs
@@ -22,13 +22,26 @@ pub struct TwitchTokenResponse {
 }
 
 /// Twitch's representation of the oauth flow for errors
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize, thiserror::Error)]
 pub struct TwitchTokenErrorResponse {
     /// Status code of error
     #[serde(with = "status_code")]
     pub status: http::StatusCode,
     /// Message attached to error
     pub message: String,
+    /// Description of the error message.
+    pub error: String,
+}
+
+impl std::fmt::Display for TwitchTokenErrorResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{error} - {message}",
+            error = self.error,
+            message = self.message
+        )
+    }
 }
 
 #[doc(hidden)]
@@ -73,12 +86,6 @@ pub mod scope {
         } else {
             Ok(None)
         }
-    }
-}
-
-impl std::fmt::Display for TwitchTokenErrorResponse {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {}", self.status.as_u16(), self.message)
     }
 }
 

--- a/src/id.rs
+++ b/src/id.rs
@@ -30,7 +30,7 @@ pub struct TwitchTokenErrorResponse {
     /// Message attached to error
     pub message: String,
     /// Description of the error message.
-    pub error: String,
+    pub error: Option<String>,
 }
 
 impl std::fmt::Display for TwitchTokenErrorResponse {
@@ -38,7 +38,10 @@ impl std::fmt::Display for TwitchTokenErrorResponse {
         write!(
             f,
             "{error} - {message}",
-            error = self.error,
+            error = self
+                .error
+                .as_deref()
+                .unwrap_or_else(|| self.status.canonical_reason().unwrap_or("Error")),
             message = self.message
         )
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,10 @@
 //! # use twitch_oauth2::{TwitchToken, UserToken, AccessToken, tokens::errors::ValidationError};
 //! # #[tokio::main]
 //! # async fn run() {
-//! # let reqwest_http_client = twitch_oauth2::dummy_http_client; // This is only here to fool doc tests
+//! # let reqwest_http_client = twitch_oauth2::client::DummyClient; // This is only here to fool doc tests
 //!     let token = AccessToken::new("sometokenherewhichisvalidornot".to_string());
 //!
-//!     match UserToken::from_existing(reqwest_http_client, token, None, None).await {
+//!     match UserToken::from_existing(&reqwest_http_client, token, None, None).await {
 //!         Ok(t) => println!("user_token: {}", t.token().secret()),
 //!         Err(e) => panic!("got error: {}", e),
 //!     }
@@ -43,24 +43,15 @@ pub use tokens::{AppAccessToken, TwitchToken, UserToken, ValidatedToken};
 
 pub use url;
 
-pub use types::{AccessToken, ClientId, ClientSecret, RefreshToken, CsrfToken};
+pub use types::{AccessToken, ClientId, ClientSecret, CsrfToken, RefreshToken};
 
 #[doc(hidden)]
-pub use types::{AccessTokenRef, ClientIdRef, ClientSecretRef, RefreshTokenRef, CsrfTokenRef};
+pub use types::{AccessTokenRef, ClientIdRef, ClientSecretRef, CsrfTokenRef, RefreshTokenRef};
 
 use self::client::Client;
 
 type HttpRequest = http::Request<Vec<u8>>;
 type HttpResponse = http::Response<Vec<u8>>;
-
-#[doc(hidden)]
-pub async fn dummy_http_client(_: HttpRequest) -> Result<HttpResponse, DummyError> {
-    Err(DummyError)
-}
-#[doc(hidden)]
-#[derive(Debug, thiserror::Error)]
-#[error("this client does not do anything, only used for documentation test that only checks code integrity")]
-pub struct DummyError;
 
 /// Generate a url with a default if `mock_api` feature is disabled, or env var is not defined or is invalid utf8
 macro_rules! mock_env_url {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ where
     Ok((access_token, expires_in, refresh_token))
 }
 
-/// Construct a request
+/// Construct a request that accepts `application/json` on default
 fn construct_request<I, K, V>(
     url: &url::Url,
     params: I,
@@ -284,6 +284,13 @@ where
     let mut req = http::Request::builder().method(method).uri(url);
     req.headers_mut()
         .map(|h| h.extend(headers.into_iter()))
+        .unwrap();
+    req.headers_mut()
+        .map(|h| {
+            if !h.contains_key(http::header::ACCEPT) {
+                h.append(http::header::ACCEPT, "application/json".parse().unwrap());
+            }
+        })
         .unwrap();
     req.body(body).unwrap()
 }

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -116,11 +116,8 @@ scope_impls!(
     WhispersRead,             scope: "whispers:read",              doc: "View your whisper messages.";
 );
 
-
 impl std::borrow::Borrow<str> for Scope {
-    fn borrow(&self) -> &str {
-        self.as_str()
-    }
+    fn borrow(&self) -> &str { self.as_str() }
 }
 
 impl From<String> for Scope {

--- a/src/scopes.rs
+++ b/src/scopes.rs
@@ -64,6 +64,14 @@ macro_rules! scope_impls {
                     _ => Scope::Other(s)
                 }
             }
+
+            /// Get the scope as a borrowed string.
+            pub fn as_str(&self) -> &str {
+                match self {
+                    $(Scope::$i => $rename,)*
+                    Self::Other(c) =>  c.as_ref()
+                }
+            }
         }
 
     };
@@ -108,13 +116,11 @@ scope_impls!(
     WhispersRead,             scope: "whispers:read",              doc: "View your whisper messages.";
 );
 
-impl Scope {
-    /// Get [Scope] as an oauth2 Scope
-    pub fn as_oauth_scope(&self) -> oauth2::Scope { oauth2::Scope::new(self.to_string()) }
-}
 
-impl From<oauth2::Scope> for Scope {
-    fn from(scope: oauth2::Scope) -> Self { Scope::parse(scope.to_string()) }
+impl std::borrow::Borrow<str> for Scope {
+    fn borrow(&self) -> &str {
+        self.as_str()
+    }
 }
 
 impl From<String> for Scope {

--- a/src/tokens.rs
+++ b/src/tokens.rs
@@ -43,7 +43,7 @@ pub trait TwitchToken {
     /// # fn t() -> UserToken {todo!()}
     /// # let user_token = t();
     /// use twitch_oauth2::TwitchToken;
-    /// println!("token: {}", user_token.token().secret().as_str());
+    /// println!("token: {}", user_token.token().secret());
     /// ```
     fn token(&self) -> &AccessToken;
     /// Get the username associated to this token
@@ -67,11 +67,11 @@ pub trait TwitchToken {
     /// # use twitch_oauth2::UserToken;
     /// # fn t() -> UserToken {todo!()}
     /// # #[tokio::main]
-    /// # async fn run() -> Result<(), Box<std::error::Error + 'static>>{
+    /// # async fn run() -> Result<(), Box<dyn std::error::Error + 'static>>{
     /// # let mut user_token = t();
-    /// use twitch_oauth2::{UserToken, TwitchToken, client::reqwest_http_client};
+    /// use twitch_oauth2::{UserToken, TwitchToken};
     /// if user_token.is_elapsed() {
-    ///     user_token.refresh_token(reqwest_http_client).await?;
+    ///     user_token.refresh_token(&reqwest::Client::builder().redirect(reqwest::redirect::Policy::none()).build()?).await?;
     /// }
     /// # Ok(()) }
     /// # fn main() {run();}

--- a/src/tokens/app_access_token.rs
+++ b/src/tokens/app_access_token.rs
@@ -31,7 +31,7 @@ pub struct AppAccessToken {
 
 impl std::fmt::Debug for AppAccessToken {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("UserToken")
+        f.debug_struct("AppAccessToken")
             .field("access_token", &self.access_token)
             .field("refresh_token", &self.refresh_token)
             .field("client_id", &self.client_id)

--- a/src/tokens/app_access_token.rs
+++ b/src/tokens/app_access_token.rs
@@ -24,8 +24,6 @@ pub struct AppAccessToken {
     struct_created: std::time::Instant,
     client_id: ClientId,
     client_secret: ClientSecret,
-    // FIXME: This should be removed
-    login: Option<String>,
     scopes: Vec<Scope>,
 }
 
@@ -50,7 +48,7 @@ impl TwitchToken for AppAccessToken {
 
     fn token(&self) -> &AccessToken { &self.access_token }
 
-    fn login(&self) -> Option<&str> { self.login.as_deref() }
+    fn login(&self) -> Option<&str> { None }
 
     fn user_id(&self) -> Option<&str> { None }
 
@@ -92,8 +90,6 @@ impl AppAccessToken {
         refresh_token: impl Into<Option<RefreshToken>>,
         client_id: impl Into<ClientId>,
         client_secret: impl Into<ClientSecret>,
-        // FIXME: Remove?
-        login: Option<String>,
         scopes: Option<Vec<Scope>>,
         expires_in: Option<std::time::Duration>,
     ) -> AppAccessToken {
@@ -102,7 +98,6 @@ impl AppAccessToken {
             refresh_token: refresh_token.into(),
             client_id: client_id.into(),
             client_secret: client_secret.into(),
-            login,
             expires_in: expires_in.unwrap_or_default(),
             struct_created: std::time::Instant::now(),
             scopes: scopes.unwrap_or_default(),
@@ -126,7 +121,6 @@ impl AppAccessToken {
             refresh_token.into(),
             validated.client_id,
             client_secret,
-            None,
             validated.scopes,
             Some(validated.expires_in),
         ))
@@ -190,7 +184,6 @@ impl AppAccessToken {
             response.refresh_token,
             client_id,
             client_secret,
-            None,
             response.scopes,
             expires_in,
         );

--- a/src/tokens/errors.rs
+++ b/src/tokens/errors.rs
@@ -61,7 +61,7 @@ pub enum RefreshTokenError<RE: std::error::Error + Send + Sync + 'static> {
     NoExpiration,
 }
 
-/// Errors for [UserTokenBuilder::get_user_token][crate::tokens::UserTokenBuilder::get_user_token]
+/// Errors for [`UserTokenBuilder::get_user_token`](crate::tokens::UserTokenBuilder::get_user_token) and [`UserToken::mock_token`](crate::tokens::UserToken::mock_token)
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum UserTokenExchangeError<RE: std::error::Error + Send + Sync + 'static> {
     /// request for token failed. {0}

--- a/src/tokens/errors.rs
+++ b/src/tokens/errors.rs
@@ -6,13 +6,17 @@ use oauth2::RequestTokenError;
 /// General errors for talking with twitch, used in [AppAccessToken::get_app_access_token][crate::tokens::AppAccessToken::get_app_access_token]
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
-pub enum TokenError<RE: std::error::Error + Send + Sync + 'static> {
+pub enum AppAccessTokenError<RE: std::error::Error + Send + Sync + 'static> {
     /// request for token failed. {0}
     Request(#[source] RequestTokenError<RE, TwitchTokenErrorResponse>),
     /// could not parse url
     ParseError(#[from] oauth2::url::ParseError),
+    /// twitch returned an unexpected status: {0}
+    TwitchError(TwitchTokenErrorResponse),
     /// could not get validation for token
     ValidationError(#[from] ValidationError<RE>),
+    /// deserializations failed
+    DeserializeError(#[from] serde_json::Error),
 }
 
 /// Errors for [validate_token][crate::validate_token]

--- a/src/tokens/errors.rs
+++ b/src/tokens/errors.rs
@@ -1,29 +1,22 @@
 //! Errors
 
-use crate::id::TwitchTokenErrorResponse;
 /// General errors for talking with twitch, used in [AppAccessToken::get_app_access_token][crate::tokens::AppAccessToken::get_app_access_token]
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum AppAccessTokenError<RE: std::error::Error + Send + Sync + 'static> {
     /// request for token failed. {0}
     Request(#[source] RE),
-    /// twitch returned an unexpected status: {0}
-    TwitchError(TwitchTokenErrorResponse),
-    /// could not get validation for token
-    ValidationError(#[from] ValidationError<RE>),
-    /// deserializations failed
-    DeserializeError(#[from] serde_json::Error),
+    /// could not parse response
+    RequestParseError(#[from] crate::RequestParseError),
 }
 
 /// Errors for [validate_token][crate::validate_token]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum ValidationError<RE: std::error::Error + Send + Sync + 'static> {
-    /// deserializations failed
-    DeserializeError(#[from] serde_json::Error),
     /// token is not authorized for use
     NotAuthorized,
-    /// twitch returned an unexpected status: {0}
-    TwitchError(TwitchTokenErrorResponse),
+    /// could not parse response
+    RequestParseError(#[from] crate::RequestParseError),
     /// failed to request validation: {0}
     Request(#[source] RE),
     // TODO: This should be in it's own error enum specifically for UserToken validation
@@ -35,8 +28,8 @@ pub enum ValidationError<RE: std::error::Error + Send + Sync + 'static> {
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum RevokeTokenError<RE: std::error::Error + Send + Sync + 'static> {
-    /// twitch returned an unexpected error: {0}
-    TwitchError(TwitchTokenErrorResponse),
+    /// could not parse response
+    RequestParseError(#[from] crate::RequestParseError),
     /// failed to do revokation: {0}
     RequestError(#[source] RE),
 }
@@ -47,10 +40,8 @@ pub enum RevokeTokenError<RE: std::error::Error + Send + Sync + 'static> {
 pub enum RefreshTokenError<RE: std::error::Error + Send + Sync + 'static> {
     /// request for token failed. {0}
     RequestError(#[source] RE),
-    /// twitch returned an unexpected error: {0}
-    TwitchError(TwitchTokenErrorResponse),
-    /// deserializations failed
-    DeserializeError(#[from] serde_json::Error),
+    /// could not parse response
+    RequestParseError(#[from] crate::RequestParseError),
     /// no client secret found
     // TODO: Include this in doc
     // A client secret is needed to request a refreshed token.
@@ -66,10 +57,8 @@ pub enum RefreshTokenError<RE: std::error::Error + Send + Sync + 'static> {
 pub enum UserTokenExchangeError<RE: std::error::Error + Send + Sync + 'static> {
     /// request for token failed. {0}
     RequestError(#[source] RE),
-    /// twitch returned an unexpected error: {0}
-    TwitchError(TwitchTokenErrorResponse),
-    /// deserializations failed
-    DeserializeError(#[from] serde_json::Error),
+    /// could not parse response
+    RequestParseError(#[from] crate::RequestParseError),
     /// State CSRF does not match.
     StateMismatch,
     /// could not get validation for token

--- a/src/tokens/errors.rs
+++ b/src/tokens/errors.rs
@@ -1,16 +1,12 @@
 //! Errors
 
 use crate::id::TwitchTokenErrorResponse;
-use oauth2::HttpResponse as OAuth2HttpResponse;
-use oauth2::RequestTokenError;
 /// General errors for talking with twitch, used in [AppAccessToken::get_app_access_token][crate::tokens::AppAccessToken::get_app_access_token]
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum AppAccessTokenError<RE: std::error::Error + Send + Sync + 'static> {
     /// request for token failed. {0}
-    Request(#[source] RequestTokenError<RE, TwitchTokenErrorResponse>),
-    /// could not parse url
-    ParseError(#[from] oauth2::url::ParseError),
+    Request(#[source] RE),
     /// twitch returned an unexpected status: {0}
     TwitchError(TwitchTokenErrorResponse),
     /// could not get validation for token
@@ -39,12 +35,10 @@ pub enum ValidationError<RE: std::error::Error + Send + Sync + 'static> {
 #[allow(missing_docs)]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum RevokeTokenError<RE: std::error::Error + Send + Sync + 'static> {
-    /// 400 Bad Request: {0}
+    /// twitch returned an unexpected error: {0}
     TwitchError(TwitchTokenErrorResponse),
     /// failed to do revokation: {0}
     RequestError(#[source] RE),
-    /// got unexpected return: {0:?}
-    Other(OAuth2HttpResponse),
 }
 
 /// Errors for [TwitchToken::refresh_token][crate::TwitchToken::refresh_token]
@@ -52,9 +46,11 @@ pub enum RevokeTokenError<RE: std::error::Error + Send + Sync + 'static> {
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum RefreshTokenError<RE: std::error::Error + Send + Sync + 'static> {
     /// request for token failed. {0}
-    RequestError(#[source] RequestTokenError<RE, TwitchTokenErrorResponse>),
-    /// could not parse url
-    ParseError(#[from] oauth2::url::ParseError),
+    RequestError(#[source] RE),
+    /// twitch returned an unexpected error: {0}
+    TwitchError(TwitchTokenErrorResponse),
+    /// deserializations failed
+    DeserializeError(#[from] serde_json::Error),
     /// no client secret found
     // TODO: Include this in doc
     // A client secret is needed to request a refreshed token.
@@ -70,8 +66,6 @@ pub enum RefreshTokenError<RE: std::error::Error + Send + Sync + 'static> {
 pub enum UserTokenExchangeError<RE: std::error::Error + Send + Sync + 'static> {
     /// request for token failed. {0}
     RequestError(#[source] RE),
-    /// could not parse url
-    ParseError(#[from] oauth2::url::ParseError),
     /// twitch returned an unexpected error: {0}
     TwitchError(TwitchTokenErrorResponse),
     /// deserializations failed
@@ -85,8 +79,7 @@ pub enum UserTokenExchangeError<RE: std::error::Error + Send + Sync + 'static> {
 /// Errors for [ImplicitUserTokenBuilder::get_user_token][crate::tokens::ImplicitUserTokenBuilder::get_user_token]
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum ImplicitUserTokenExchangeError<RE: std::error::Error + Send + Sync + 'static> {
-    /// could not parse url
-    ParseError(#[from] oauth2::url::ParseError),
+    // FIXME: should be TwitchTokenErrorResponse
     /// twitch returned an error: {error:?} - {description:?}
     TwitchError {
         /// Error type

--- a/src/tokens/user_token.rs
+++ b/src/tokens/user_token.rs
@@ -315,8 +315,8 @@ impl UserTokenBuilder {
         params.insert("grant_type", "authorization_code");
         params.insert("redirect_uri", self.redirect_url.as_str());
         let req = HttpRequest {
-            url: oauth2::url::Url::parse_with_params(crate::TOKEN_URL, &params)
-                .expect("unexpectedly failed to parse revoke url"),
+            url: oauth2::url::Url::parse_with_params(&crate::TOKEN_URL, &params)
+                .expect("unexpectedly failed to parse token url"),
             method: Method::POST,
             headers: HeaderMap::new(),
             body: vec![],

--- a/src/tokens/user_token.rs
+++ b/src/tokens/user_token.rs
@@ -560,11 +560,10 @@ mod tests {
     #[test]
     fn generate_url() {
         dbg!(UserTokenBuilder::new(
-            ClientId::new("clientid".to_string()),
-            ClientSecret::new("secret".to_string()),
-            oauth2::RedirectUrl::new("https://localhost".to_string()).unwrap(),
+            ClientId::new("clientid"),
+            ClientSecret::new("secret"),
+            url::Url::parse("https://localhost").unwrap(),
         )
-        .unwrap()
         .force_verify(true)
         .generate_url()
         .0
@@ -575,15 +574,14 @@ mod tests {
     #[ignore]
     async fn get_token() {
         let mut t = UserTokenBuilder::new(
-            ClientId::new("clientid".to_string()),
-            ClientSecret::new("secret".to_string()),
-            crate::RedirectUrl::new(r#"https://localhost"#.to_string()).unwrap(),
+            ClientId::new("clientid"),
+            ClientSecret::new("secret"),
+            url::Url::parse(r#"https://localhost"#).unwrap(),
         )
-        .unwrap()
         .force_verify(true);
-        t.csrf = Some(oauth2::CsrfToken::new("random".to_string()));
+        t.csrf = Some(crate::CsrfToken::new("random"));
         let token = t
-            .get_user_token(crate::client::surf_http_client, "random", "authcode")
+            .get_user_token(&surf::Client::new(), "random", "authcode")
             .await
             .unwrap();
         println!("token: {:?} - {}", token, token.access_token.secret());
@@ -593,16 +591,15 @@ mod tests {
     #[ignore]
     async fn get_implicit_token() {
         let mut t = ImplicitUserTokenBuilder::new(
-            ClientId::new("clientid".to_string()),
-            crate::RedirectUrl::new(r#"http://localhost/twitch/register"#.to_string()).unwrap(),
+            ClientId::new("clientid"),
+            url::Url::parse(r#"http://localhost/twitch/register"#).unwrap(),
         )
-        .unwrap()
         .force_verify(true);
         println!("{}", t.generate_url().0);
-        t.csrf = Some(oauth2::CsrfToken::new("random".to_string()));
+        t.csrf = Some(crate::CsrfToken::new("random"));
         let token = t
             .get_user_token(
-                crate::client::surf_http_client,
+                &surf::Client::new(),
                 Some("random"),
                 Some("authcode"),
                 None,

--- a/src/tokens/user_token.rs
+++ b/src/tokens/user_token.rs
@@ -146,12 +146,11 @@ impl UserToken {
     ///     &reqwest::Client::builder()
     ///         .redirect(reqwest::redirect::Policy::none())
     ///         .build()?
-    ///     ),
     ///     // Pass in the mock api url to mock/users, if this is none, we'll assume the host is the same as the `/auth` url, but living instead on `/mock/users`
     ///     None,
     ///     "mockclientid".into(),
     ///     "mockclientsecret".into(),
-    ///     "user_id".into(),
+    ///     "user_id",
     ///     vec![],
     ///     ).await?;
     /// # Ok(())}

--- a/src/tokens/user_token.rs
+++ b/src/tokens/user_token.rs
@@ -145,7 +145,7 @@ impl UserToken {
     /// let token = twitch_oauth2::UserToken::mock_token(
     ///     &reqwest::Client::builder()
     ///         .redirect(reqwest::redirect::Policy::none())
-    ///         .build()?
+    ///         .build()?,
     ///     // Pass in the mock api url to mock/users, if this is none, we'll assume the host is the same as the `/auth` url, but living instead on `/mock/users`
     ///     None,
     ///     "mockclientid".into(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,108 @@
+//! Types used in OAUTH2 flow.
+
+use std::fmt;
+
+/// A Client Id
+#[aliri_braid::braid(serde)]
+pub struct ClientId;
+
+/// A Client Secret
+#[aliri_braid::braid(display_impl = "owned", debug_impl = "owned", serde)]
+pub struct ClientSecret;
+
+impl fmt::Debug for ClientSecretRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[redacted client secret]")
+    }
+}
+impl fmt::Display for ClientSecretRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[redacted client secret]")
+    }
+}
+
+/// An Access Token
+#[aliri_braid::braid(display_impl = "owned", debug_impl = "owned", serde)]
+pub struct AccessToken;
+
+impl fmt::Debug for AccessTokenRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[redacted access token]")
+    }
+}
+impl fmt::Display for AccessTokenRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[redacted access token]")
+    }
+}
+
+/// A Refresh Token
+#[aliri_braid::braid(display_impl = "owned", debug_impl = "owned", serde)]
+pub struct RefreshToken;
+
+impl fmt::Debug for RefreshTokenRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[redacted refresh token]")
+    }
+}
+impl fmt::Display for RefreshTokenRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[redacted refresh token]")
+    }
+}
+
+/// A Csrf Token
+#[aliri_braid::braid(display_impl = "owned", debug_impl = "owned", serde)]
+pub struct CsrfToken;
+
+impl fmt::Debug for CsrfTokenRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[redacted csrf token]")
+    }
+}
+impl fmt::Display for CsrfTokenRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("[redacted csrf token]")
+    }
+}
+
+impl CsrfToken {
+    /// Make a new random CSRF token.
+    pub fn new_random() -> CsrfToken { Self::new_random_len(16) }
+
+    /// Make a new random CSRF token with given amount of bytes
+    pub fn new_random_len(len: u32) -> CsrfToken {
+        use rand::Rng as _;
+        let random_bytes: Vec<u8> = (0..len).map(|_| rand::thread_rng().gen::<u8>()).collect();
+        CsrfToken::new(base64::encode_config(
+            &random_bytes,
+            base64::URL_SAFE_NO_PAD,
+        ))
+    }
+}
+
+impl ClientSecretRef {
+    /// Get the secret from this string.
+    ///
+    /// This function is the same as [`ClientSecret::as_str`](ClientSecretRef::as_str), but has another name for searchability, prefer to use this function.
+    pub fn secret(&self) -> &str { self.as_str() }
+}
+
+impl AccessTokenRef {
+    /// Get the secret from this string.
+    ///
+    /// This function is the same as [`AccessToken::as_str`](AccessTokenRef::as_str), but has another name for searchability, prefer to use this function.
+    pub fn secret(&self) -> &str { self.as_str() }
+}
+impl RefreshTokenRef {
+    /// Get the secret from this string.
+    ///
+    /// This function is the same as [`RefreshToken::as_str`](RefreshTokenRef::as_str), but has another name for searchability, prefer to use this function.
+    pub fn secret(&self) -> &str { self.as_str() }
+}
+impl CsrfTokenRef {
+    /// Get the secret from this string.
+    ///
+    /// This function is the same as [`CsrfToken::as_str`](CsrfTokenRef::as_str), but has another name for searchability, prefer to use this function.
+    pub fn secret(&self) -> &str { self.as_str() }
+}


### PR DESCRIPTION
- make mocking work for app access tokens
- Make Scope Borrow<str>
- implement mocking and refactor out `oauth2`
- fix tests
- fix mock example
- make mocking a user_token work
- make it possible to omit users url for validating with mock
